### PR TITLE
Fix missing enchants display

### DIFF
--- a/addon.lua
+++ b/addon.lua
@@ -679,19 +679,17 @@ do
         -- retail
         INVTYPE_CHEST = true,
         INVTYPE_ROBE = true,
+        INVTYPE_LEGS = true,
         INVTYPE_FEET = true,
         INVTYPE_WRIST = true,
-        INVTYPE_HAND = true,
         INVTYPE_FINGER = true,
         INVTYPE_CLOAK = true,
         INVTYPE_WEAPON = true,
-        -- INVTYPE_SHIELD = true, -- ...are there?
         INVTYPE_2HWEAPON = true,
         INVTYPE_WEAPONMAINHAND = true,
         INVTYPE_RANGED = true,
         INVTYPE_RANGEDRIGHT = true,
         INVTYPE_WEAPONOFFHAND = true,
-        INVTYPE_HOLDABLE = true,
     }
     function ns.ItemIsMissingEnchants(itemLink)
         if not itemLink then return false end


### PR DESCRIPTION
Missing enchants was not displayed for legs (enchant is made by tailoring).
Missing enchants was displayed for hands and off-hand items, but these are not enchantable in Dragonflight.