### PR TITLE
Classic - Wand slot "missing enchant"

### DIFF
--- a/addon.lua
+++ b/addon.lua
@@ -898,6 +898,7 @@ do
         if not itemLink then return false end
         local equipLoc = select(4, C_Item.GetItemInfoInstant(itemLink))
         if not enchantable[equipLoc] then return false end
+        if select(3, GetItemInfoInstant(itemLink)) == "Wands" then return false end
         local enchantID = select(3, strsplit(":", itemLink))
         if enchantID == "" then return true end
         return false


### PR DESCRIPTION
Prevents wand slot from being labelled as "missing enchant." There are no wand enchants in Classic.