### PR TITLE
Mark head and shoulder slots as enchantable, and wrist and back as not-enchantable, in retail.

### DIFF
--- a/addon.lua
+++ b/addon.lua
@@ -1117,13 +1117,13 @@ do
         INVTYPE_HOLDABLE = true,
     } or {
         -- retail
+        INVTYPE_HEAD = true,
+        INVTYPE_SHOULDER = true,
         INVTYPE_CHEST = true,
         INVTYPE_ROBE = true,
         INVTYPE_LEGS = true,
         INVTYPE_FEET = true,
-        INVTYPE_WRIST = true,
         INVTYPE_FINGER = enchantableRings,
-        INVTYPE_CLOAK = true,
         INVTYPE_WEAPON = true,
         INVTYPE_2HWEAPON = true,
         INVTYPE_WEAPONMAINHAND = true,


### PR DESCRIPTION
Mark head and shoulder slots as enchantable, and wrist and back as not-enchantable, in retail.

Going off the [BIS enchant lists on wowhead](https://www.wowhead.com/guide/classes/demon-hunter/vengeance/enchants-gems-pve-tank), the table in the addon needs to be updated.

<img width="662" height="531" alt="image" src="https://github.com/user-attachments/assets/98b85963-fb56-4d61-b2fa-9dd2009ea228" />
